### PR TITLE
Changed link with text to markdown syntax

### DIFF
--- a/ox-slack.el
+++ b/ox-slack.el
@@ -169,7 +169,7 @@ a communication channel."
                   (org-export-file-uri (funcall link-org-files-as-md raw-path)))
                  (t raw-path))))
           (if (not contents) (format "%s" path)
-            (format "*%s* (%s)" contents path)))))))
+            (format "[%s](%s)" contents path)))))))
 
 (defun org-slack-verbatim (_verbatim contents _info)
   "Transcode VERBATIM from Org to Slack.


### PR DESCRIPTION
This change makes links with text more nicely formatted.

Closes: #8